### PR TITLE
Windows: add VST_CLEANSER support for outlet_new/inlet_new and global symbol stubs

### DIFF
--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -64,6 +64,10 @@ static t_class *inlet_class, *pointerinlet_class, *floatinlet_class,
 t_inlet *inlet_new(t_object *owner, t_pd *dest, t_symbol *s1, t_symbol *s2)
 {
     t_inlet *x = (t_inlet *)pd_new(inlet_class), *y, *y2;
+#ifdef VST_CLEANSER
+    if (s1) vst_cleanser(&s1);
+    if (s2) vst_cleanser(&s2);
+#endif
     x->i_owner = owner;
     x->i_dest = dest;
     if (s1 == &s_signal)
@@ -555,6 +559,9 @@ void obj_dosettracing(t_object *ob, int onoff)
 t_outlet *outlet_new(t_object *owner, t_symbol *s)
 {
     t_outlet *x = (t_outlet *)getbytes(sizeof(*x)), *y, *y2;
+#ifdef VST_CLEANSER
+    if (s) vst_cleanser(&s);
+#endif
     x->o_owner = owner;
     x->o_next = 0;
     if ((y = owner->ob_outlet))

--- a/src/pd_compat_globals.c
+++ b/src/pd_compat_globals.c
@@ -1,0 +1,73 @@
+/* pd_compat_globals.c
+ *
+ * Compatibility layer for third-party Pd externals compiled against vanilla Pd
+ * (non-PDINSTANCE mode). In PDINSTANCE mode, symbols like s_bang, s_float, etc.
+ * become per-instance macros and are NOT exported as global variables. This file
+ * provides real global t_symbol variables that satisfy the linker, and a
+ * vst_cleanser() function that translates these "stale" global pointers to the
+ * correct per-instance symbols at Pd API entry points.
+ *
+ * See m_pd.h lines 1127-1137 for the VST_CLEANSER design by Miller Puckette.
+ */
+
+#include "m_pd.h"
+
+#if defined(PDINSTANCE) && defined(VST_CLEANSER)
+
+/* Undef the per-instance macros so we can define real global variables.
+ * After this point, s_bang etc. refer to our globals, NOT pd_this->pd_s_bang.
+ * We access the per-instance versions via pd_this->pd_s_xxx directly. */
+#undef s_pointer
+#undef s_float
+#undef s_symbol
+#undef s_bang
+#undef s_list
+#undef s_anything
+#undef s_signal
+#undef s__N
+#undef s__X
+#undef s_x
+#undef s_y
+#undef s_
+
+/* Global t_symbol variables exported from pd.dll.
+ * Initialized with correct s_name so that direct dereferences (e.g.
+ * s_bang.s_name) return the expected string. The addresses of these
+ * globals serve as identity markers for vst_cleanser(). */
+t_symbol s_pointer  = {"pointer",  0, 0};
+t_symbol s_float    = {"float",    0, 0};
+t_symbol s_symbol   = {"symbol",   0, 0};
+t_symbol s_bang     = {"bang",     0, 0};
+t_symbol s_list     = {"list",     0, 0};
+t_symbol s_anything = {"anything", 0, 0};
+t_symbol s_signal   = {"signal",   0, 0};
+t_symbol s__N       = {"N",        0, 0};
+t_symbol s__X       = {"X",        0, 0};
+t_symbol s_x        = {"x",        0, 0};
+t_symbol s_y        = {"y",        0, 0};
+t_symbol s_         = {"",         0, 0};
+
+/* vst_cleanser - translate global symbol pointers to per-instance equivalents.
+ *
+ * Called at Pd API entry points (pd_bind, pd_unbind, pd_symbol, pd_list,
+ * pd_anything, class_doaddmethod) to intercept "stale" global symbol pointers
+ * from vanilla-Pd-compiled externals and replace them with the correct
+ * per-instance symbol from the current pd_this. */
+void vst_cleanser(t_symbol **s)
+{
+    t_symbol *sym = *s;
+    if      (sym == &s_pointer)  *s = &(pd_this->pd_s_pointer);
+    else if (sym == &s_float)    *s = &(pd_this->pd_s_float);
+    else if (sym == &s_symbol)   *s = &(pd_this->pd_s_symbol);
+    else if (sym == &s_bang)     *s = &(pd_this->pd_s_bang);
+    else if (sym == &s_list)     *s = &(pd_this->pd_s_list);
+    else if (sym == &s_anything) *s = &(pd_this->pd_s_anything);
+    else if (sym == &s_signal)   *s = &(pd_this->pd_s_signal);
+    else if (sym == &s__N)       *s = &(pd_this->pd_s__N);
+    else if (sym == &s__X)       *s = &(pd_this->pd_s__X);
+    else if (sym == &s_x)        *s = &(pd_this->pd_s_x);
+    else if (sym == &s_y)        *s = &(pd_this->pd_s_y);
+    else if (sym == &s_)         *s = &(pd_this->pd_s_);
+}
+
+#endif /* PDINSTANCE && VST_CLEANSER */


### PR DESCRIPTION
### Description

When building `pd-multi` as a **shared library** with `PDINSTANCE=1` (per-instance symbols), the pre-defined global symbols (`s_bang`, `s_float`, `s_list`, …) become macros and are no longer exported as global variables.  

Third-party externals compiled against vanilla Pd expect these symbols to be present as globals, resulting in **Error 127 (ERROR_PROC_NOT_FOUND)** when loading on Windows.

### Solution

This PR adds proper VST_CLEANSER compatibility layer for the Windows plugin use case:

- **New file**: `src/pd_compat_globals.c`  
  - Exports 12 critical global `t_symbol` stubs with correct `.s_name` values  
  - Provides `vst_cleanser()` function that translates stale global symbol pointers to the current per-instance equivalents at runtime

- **Extended VST_CLEANSER coverage** in `src/m_obj.c`:
  - Added support for `outlet_new()` and `inlet_new()`
  - These two functions internally store symbol pointers (especially `&s_signal`, `&s_anything`, etc.) that are later compared directly by the Pd core.

### Testing
- Successfully tested on Windows 10/11 with plugdata (Win32 plugin mode)
- Multiple third-party externals that previously failed to load now load and run correctly

However, I believe this code warrants a thorough review and extensive testing! 


<img width="2559" height="1359" alt="屏幕截图 2026-03-24 153401" src="https://github.com/user-attachments/assets/8a207243-5def-45cd-b880-cdd86fb95e44" />

<img width="2559" height="1359" alt="屏幕截图 2026-03-24 154202" src="https://github.com/user-attachments/assets/520b58e8-d2f7-48ef-8719-20751555c152" />